### PR TITLE
feat: add Novita AI as LLM provider

### DIFF
--- a/docker/config/openclaw.json
+++ b/docker/config/openclaw.json
@@ -9,6 +9,17 @@
 
   "models": {
     "providers": {
+      "novita": {
+        "baseUrl": "https://api.novita.ai/openai",
+        "apiKey": "${NOVITA_API_KEY:-}",
+        "api": "openai-completions",
+        "models": [
+          {"id": "moonshotai/kimi-k2.5", "name": "Kimi K2.5"},
+          {"id": "deepseek/deepseek-v3.2", "name": "DeepSeek V3.2"},
+          {"id": "zai-org/glm-5", "name": "GLM-5"},
+          {"id": "qwen/qwen3-embedding-0.6b", "name": "Qwen3 Embedding 0.6B"}
+        ]
+      },
       "prismer-gateway": {
         "baseUrl": "http://34.60.178.0:3000/v1",
         "apiKey": "sk-placeholder",

--- a/web/.env.docker.example
+++ b/web/.env.docker.example
@@ -15,8 +15,11 @@ DATABASE_URL="file:./prisma/dev.db"
 # OPENAI_API_BASE_URL=https://api.openai.com/v1
 # AGENT_DEFAULT_MODEL=gpt-4o
 
+# --- Optional: LLM provider selection ---
+# Explicit provider choice. If unset, auto-detects from available API keys (novita → openai).
+# LLM_PROVIDER=novita     # or: openai
+
 # --- Optional: Novita AI provider (OpenAI-compatible, https://api.novita.ai/openai) ---
-# When set, Novita AI takes priority over OPENAI_API_KEY.
 # Default model: moonshotai/kimi-k2.5  (also available: deepseek/deepseek-v3.2, zai-org/glm-5)
 # NOVITA_API_KEY=
 # NOVITA_DEFAULT_MODEL=moonshotai/kimi-k2.5

--- a/web/.env.docker.example
+++ b/web/.env.docker.example
@@ -15,10 +15,11 @@ DATABASE_URL="file:./prisma/dev.db"
 # OPENAI_API_BASE_URL=https://api.openai.com/v1
 # AGENT_DEFAULT_MODEL=gpt-4o
 
-# --- Optional: Novita AI (OpenAI-compatible alternative) ---
-# NOVITA_API_KEY=your-novita-key-here
-# To use Novita as the LLM backend, set OPENAI_API_BASE_URL=https://api.novita.ai/openai
-# and OPENAI_API_KEY to your Novita API key, then set AGENT_DEFAULT_MODEL=moonshotai/kimi-k2.5
+# --- Optional: Novita AI provider (OpenAI-compatible, https://api.novita.ai/openai) ---
+# When set, Novita AI takes priority over OPENAI_API_KEY.
+# Default model: moonshotai/kimi-k2.5  (also available: deepseek/deepseek-v3.2, zai-org/glm-5)
+# NOVITA_API_KEY=
+# NOVITA_DEFAULT_MODEL=moonshotai/kimi-k2.5
 
 # --- Optional: Client-side AI (PDF Reader features) ---
 # NEXT_PUBLIC_OPENAI_API_KEY=

--- a/web/.env.docker.example
+++ b/web/.env.docker.example
@@ -15,6 +15,11 @@ DATABASE_URL="file:./prisma/dev.db"
 # OPENAI_API_BASE_URL=https://api.openai.com/v1
 # AGENT_DEFAULT_MODEL=gpt-4o
 
+# --- Optional: Novita AI (OpenAI-compatible alternative) ---
+# NOVITA_API_KEY=your-novita-key-here
+# To use Novita as the LLM backend, set OPENAI_API_BASE_URL=https://api.novita.ai/openai
+# and OPENAI_API_KEY to your Novita API key, then set AGENT_DEFAULT_MODEL=moonshotai/kimi-k2.5
+
 # --- Optional: Client-side AI (PDF Reader features) ---
 # NEXT_PUBLIC_OPENAI_API_KEY=
 # NEXT_PUBLIC_OPENAI_API_BASE_URL=https://api.openai.com/v1

--- a/web/src/app/api/ai/chat/route.ts
+++ b/web/src/app/api/ai/chat/route.ts
@@ -1,0 +1,104 @@
+/**
+ * POST /api/ai/chat
+ *
+ * Server-side proxy to the configured LLM provider.
+ * Provider selection priority:
+ *   1. Novita AI  (NOVITA_API_KEY)
+ *   2. OpenAI / custom OpenAI-compatible  (OPENAI_API_KEY + optional OPENAI_API_BASE_URL)
+ *
+ * Accepts an OpenAI-compatible request body and proxies it verbatim.
+ * Supports both streaming (SSE) and non-streaming responses.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getNovitaProviderConfig, NOVITA_DEFAULT_MODEL } from '@/lib/llm/providers/novita';
+import type { ProviderConfig } from '@/lib/llm/types';
+
+// ----------------------------------------------------------------
+// Provider resolution
+// ----------------------------------------------------------------
+
+function resolveProvider(): ProviderConfig | null {
+  // 1. Novita AI
+  const novita = getNovitaProviderConfig();
+  if (novita) return novita;
+
+  // 2. OpenAI / custom OpenAI-compatible
+  const apiKey = process.env.OPENAI_API_KEY || process.env.OPENAI_APIKEY || process.env.AI_API_KEY;
+  if (apiKey) {
+    return {
+      provider: 'openai',
+      apiKey,
+      baseUrl: process.env.OPENAI_API_BASE_URL || 'https://api.openai.com/v1',
+      defaultModel: process.env.AGENT_DEFAULT_MODEL || 'gpt-4o',
+      enabled: true,
+    };
+  }
+
+  return null;
+}
+
+// ----------------------------------------------------------------
+// Route handler
+// ----------------------------------------------------------------
+
+export async function POST(req: NextRequest) {
+  const provider = resolveProvider();
+
+  if (!provider) {
+    return NextResponse.json(
+      { error: 'No LLM provider configured. Set NOVITA_API_KEY or OPENAI_API_KEY.' },
+      { status: 503 }
+    );
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  // Resolve 'default' model to provider's default
+  if (body.model === 'default' || !body.model) {
+    body = {
+      ...body,
+      model: provider.defaultModel ?? (provider.provider === 'novita' ? NOVITA_DEFAULT_MODEL : 'gpt-4o'),
+    };
+  }
+
+  const upstream = `${provider.baseUrl}/chat/completions`;
+
+  const upstreamRes = await fetch(upstream, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${provider.apiKey}`,
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!upstreamRes.ok) {
+    const text = await upstreamRes.text().catch(() => '');
+    return NextResponse.json(
+      { error: `Provider error (${upstreamRes.status})`, details: text },
+      { status: upstreamRes.status }
+    );
+  }
+
+  // Streaming: pipe SSE straight through
+  if (body.stream === true) {
+    return new Response(upstreamRes.body, {
+      status: 200,
+      headers: {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        'X-Accel-Buffering': 'no',
+      },
+    });
+  }
+
+  // Non-streaming: return JSON
+  const data = await upstreamRes.json();
+  return NextResponse.json(data);
+}

--- a/web/src/app/api/ai/chat/route.ts
+++ b/web/src/app/api/ai/chat/route.ts
@@ -2,9 +2,9 @@
  * POST /api/ai/chat
  *
  * Server-side proxy to the configured LLM provider.
- * Provider selection priority:
- *   1. Novita AI  (NOVITA_API_KEY)
- *   2. OpenAI / custom OpenAI-compatible  (OPENAI_API_KEY + optional OPENAI_API_BASE_URL)
+ * Provider selection:
+ *   1. Explicit LLM_PROVIDER env var (e.g. LLM_PROVIDER=openai)
+ *   2. Auto-detect: first provider whose API key is set (novita → openai)
  *
  * Accepts an OpenAI-compatible request body and proxies it verbatim.
  * Supports both streaming (SSE) and non-streaming responses.
@@ -18,21 +18,41 @@ import type { ProviderConfig } from '@/lib/llm/types';
 // Provider resolution
 // ----------------------------------------------------------------
 
-function resolveProvider(): ProviderConfig | null {
-  // 1. Novita AI
-  const novita = getNovitaProviderConfig();
-  if (novita) return novita;
-
-  // 2. OpenAI / custom OpenAI-compatible
+function getOpenAIProviderConfig(): ProviderConfig | null {
   const apiKey = process.env.OPENAI_API_KEY || process.env.OPENAI_APIKEY || process.env.AI_API_KEY;
-  if (apiKey) {
-    return {
-      provider: 'openai',
-      apiKey,
-      baseUrl: process.env.OPENAI_API_BASE_URL || 'https://api.openai.com/v1',
-      defaultModel: process.env.AGENT_DEFAULT_MODEL || 'gpt-4o',
-      enabled: true,
-    };
+  if (!apiKey) return null;
+  return {
+    provider: 'openai',
+    apiKey,
+    baseUrl: process.env.OPENAI_API_BASE_URL || 'https://api.openai.com/v1',
+    defaultModel: process.env.AGENT_DEFAULT_MODEL || 'gpt-4o',
+    enabled: true,
+  };
+}
+
+const PROVIDER_FACTORIES: Record<string, () => ProviderConfig | null> = {
+  novita: getNovitaProviderConfig,
+  openai: getOpenAIProviderConfig,
+};
+
+/**
+ * Resolve the active LLM provider.
+ *
+ * Selection order:
+ *   1. Explicit LLM_PROVIDER env var (e.g. LLM_PROVIDER=openai)
+ *   2. First provider whose API key is present (novita → openai)
+ */
+export function resolveProvider(): ProviderConfig | null {
+  // 1. Explicit choice via LLM_PROVIDER
+  const explicit = process.env.LLM_PROVIDER?.toLowerCase();
+  if (explicit && PROVIDER_FACTORIES[explicit]) {
+    return PROVIDER_FACTORIES[explicit]();
+  }
+
+  // 2. Auto-detect: first configured provider wins
+  for (const factory of Object.values(PROVIDER_FACTORIES)) {
+    const config = factory();
+    if (config) return config;
   }
 
   return null;
@@ -76,6 +96,7 @@ export async function POST(req: NextRequest) {
       'Authorization': `Bearer ${provider.apiKey}`,
     },
     body: JSON.stringify(body),
+    signal: AbortSignal.timeout(30_000),
   });
 
   if (!upstreamRes.ok) {

--- a/web/src/app/api/config/client/route.ts
+++ b/web/src/app/api/config/client/route.ts
@@ -41,8 +41,9 @@ export async function GET() {
       // AI configuration - Only return availability status, not API Key
       // Supports multiple naming formats
       aiEnabled: !!(
-        process.env.OPENAI_API_KEY 
-        || process.env.OPENAI_APIKEY 
+        process.env.NOVITA_API_KEY
+        || process.env.OPENAI_API_KEY
+        || process.env.OPENAI_APIKEY
         || process.env.AI_API_KEY
       ),
       

--- a/web/src/lib/llm/providers/novita.ts
+++ b/web/src/lib/llm/providers/novita.ts
@@ -1,0 +1,37 @@
+/**
+ * Novita AI Provider
+ *
+ * OpenAI-compatible provider via https://api.novita.ai/openai
+ * API key: NOVITA_API_KEY environment variable
+ */
+
+import type { ProviderConfig } from '../types';
+
+export const NOVITA_BASE_URL = 'https://api.novita.ai/openai';
+
+export const NOVITA_DEFAULT_MODEL = 'moonshotai/kimi-k2.5';
+
+export const NOVITA_MODELS = [
+  'moonshotai/kimi-k2.5',
+  'deepseek/deepseek-v3.2',
+  'zai-org/glm-5',
+] as const;
+
+export const NOVITA_EMBEDDING_MODEL = 'qwen/qwen3-embedding-0.6b';
+
+/**
+ * Build Novita provider config from environment variables.
+ * Returns null if NOVITA_API_KEY is not set.
+ */
+export function getNovitaProviderConfig(): ProviderConfig | null {
+  const apiKey = process.env.NOVITA_API_KEY;
+  if (!apiKey) return null;
+
+  return {
+    provider: 'novita',
+    apiKey,
+    baseUrl: NOVITA_BASE_URL,
+    defaultModel: process.env.NOVITA_DEFAULT_MODEL || NOVITA_DEFAULT_MODEL,
+    enabled: true,
+  };
+}

--- a/web/src/lib/llm/types.ts
+++ b/web/src/lib/llm/types.ts
@@ -13,7 +13,7 @@
 /**
  * Supported LLM providers
  */
-export type LLMProvider = 'anthropic' | 'openai' | 'prismer' | 'custom';
+export type LLMProvider = 'anthropic' | 'openai' | 'prismer' | 'novita' | 'custom';
 
 /**
  * Model information
@@ -190,6 +190,10 @@ export const MODEL_PRICING: Record<string, { input: number; output: number }> = 
   'o1': { input: 15.0, output: 60.0 },
   'o1-mini': { input: 3.0, output: 12.0 },
   'o3-mini': { input: 1.1, output: 4.4 },
+  // Novita AI (OpenAI-compatible, https://api.novita.ai/openai)
+  'moonshotai/kimi-k2.5': { input: 1.0, output: 3.0 },
+  'deepseek/deepseek-v3.2': { input: 1.0, output: 3.0 },
+  'zai-org/glm-5': { input: 1.0, output: 3.0 },
   // Default fallback
   'default': { input: 1.0, output: 3.0 },
 };

--- a/web/src/lib/llm/types.ts
+++ b/web/src/lib/llm/types.ts
@@ -191,9 +191,10 @@ export const MODEL_PRICING: Record<string, { input: number; output: number }> = 
   'o1-mini': { input: 3.0, output: 12.0 },
   'o3-mini': { input: 1.1, output: 4.4 },
   // Novita AI (OpenAI-compatible, https://api.novita.ai/openai)
-  'moonshotai/kimi-k2.5': { input: 1.0, output: 3.0 },
-  'deepseek/deepseek-v3.2': { input: 1.0, output: 3.0 },
-  'zai-org/glm-5': { input: 1.0, output: 3.0 },
+  'moonshotai/kimi-k2.5': { input: 0.6, output: 3.0 },
+  'deepseek/deepseek-v3.2': { input: 0.27, output: 0.4 },
+  'zai-org/glm-5': { input: 1.0, output: 3.2 },
+  'qwen/qwen3-embedding-0.6b': { input: 0.02, output: 0.0 },
   // Default fallback
   'default': { input: 1.0, output: 3.0 },
 };

--- a/web/tests/unit/llm/novita-provider.test.ts
+++ b/web/tests/unit/llm/novita-provider.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { getNovitaProviderConfig, NOVITA_BASE_URL, NOVITA_DEFAULT_MODEL, NOVITA_MODELS } from '@/lib/llm/providers/novita';
+import { calculateCost, MODEL_PRICING } from '@/lib/llm/types';
+
+// Helper to set/restore env vars
+function withEnv(vars: Record<string, string | undefined>, fn: () => void) {
+  const originals: Record<string, string | undefined> = {};
+  for (const key of Object.keys(vars)) {
+    originals[key] = process.env[key];
+    if (vars[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = vars[key];
+    }
+  }
+  try {
+    fn();
+  } finally {
+    for (const key of Object.keys(originals)) {
+      if (originals[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = originals[key];
+      }
+    }
+  }
+}
+
+describe('getNovitaProviderConfig', () => {
+  it('returns null when NOVITA_API_KEY is not set', () => {
+    withEnv({ NOVITA_API_KEY: undefined }, () => {
+      expect(getNovitaProviderConfig()).toBeNull();
+    });
+  });
+
+  it('returns config when NOVITA_API_KEY is set', () => {
+    withEnv({ NOVITA_API_KEY: 'test-key', NOVITA_DEFAULT_MODEL: undefined }, () => {
+      const config = getNovitaProviderConfig();
+      expect(config).not.toBeNull();
+      expect(config!.provider).toBe('novita');
+      expect(config!.apiKey).toBe('test-key');
+      expect(config!.baseUrl).toBe(NOVITA_BASE_URL);
+      expect(config!.defaultModel).toBe(NOVITA_DEFAULT_MODEL);
+      expect(config!.enabled).toBe(true);
+    });
+  });
+
+  it('respects NOVITA_DEFAULT_MODEL override', () => {
+    withEnv({ NOVITA_API_KEY: 'test-key', NOVITA_DEFAULT_MODEL: 'deepseek/deepseek-v3.2' }, () => {
+      const config = getNovitaProviderConfig();
+      expect(config!.defaultModel).toBe('deepseek/deepseek-v3.2');
+    });
+  });
+});
+
+describe('resolveProvider', () => {
+  // Import dynamically so env vars are read at call time
+  let resolveProvider: typeof import('@/app/api/ai/chat/route').resolveProvider;
+
+  beforeEach(async () => {
+    const mod = await import('@/app/api/ai/chat/route');
+    resolveProvider = mod.resolveProvider;
+  });
+
+  it('returns null when no provider keys are set', () => {
+    withEnv({ NOVITA_API_KEY: undefined, OPENAI_API_KEY: undefined, OPENAI_APIKEY: undefined, AI_API_KEY: undefined, LLM_PROVIDER: undefined }, () => {
+      expect(resolveProvider()).toBeNull();
+    });
+  });
+
+  it('returns novita when only NOVITA_API_KEY is set', () => {
+    withEnv({ NOVITA_API_KEY: 'nk', OPENAI_API_KEY: undefined, OPENAI_APIKEY: undefined, AI_API_KEY: undefined, LLM_PROVIDER: undefined }, () => {
+      const config = resolveProvider();
+      expect(config!.provider).toBe('novita');
+    });
+  });
+
+  it('returns openai when only OPENAI_API_KEY is set', () => {
+    withEnv({ NOVITA_API_KEY: undefined, OPENAI_API_KEY: 'ok', OPENAI_APIKEY: undefined, AI_API_KEY: undefined, LLM_PROVIDER: undefined }, () => {
+      const config = resolveProvider();
+      expect(config!.provider).toBe('openai');
+    });
+  });
+
+  it('LLM_PROVIDER=openai overrides auto-detection even when both keys exist', () => {
+    withEnv({ NOVITA_API_KEY: 'nk', OPENAI_API_KEY: 'ok', LLM_PROVIDER: 'openai' }, () => {
+      const config = resolveProvider();
+      expect(config!.provider).toBe('openai');
+    });
+  });
+
+  it('LLM_PROVIDER=novita selects novita explicitly', () => {
+    withEnv({ NOVITA_API_KEY: 'nk', OPENAI_API_KEY: 'ok', LLM_PROVIDER: 'novita' }, () => {
+      const config = resolveProvider();
+      expect(config!.provider).toBe('novita');
+    });
+  });
+});
+
+describe('MODEL_PRICING', () => {
+  it('has entries for all Novita models', () => {
+    for (const model of NOVITA_MODELS) {
+      expect(MODEL_PRICING[model]).toBeDefined();
+      expect(MODEL_PRICING[model].input).toBeGreaterThan(0);
+      expect(MODEL_PRICING[model].output).toBeGreaterThan(0);
+    }
+  });
+
+  it('has entry for Novita embedding model', () => {
+    expect(MODEL_PRICING['qwen/qwen3-embedding-0.6b']).toBeDefined();
+    expect(MODEL_PRICING['qwen/qwen3-embedding-0.6b'].input).toBeGreaterThan(0);
+  });
+
+  it('models have distinct pricing (not placeholders)', () => {
+    const prices = NOVITA_MODELS.map(m => MODEL_PRICING[m]);
+    const unique = new Set(prices.map(p => `${p.input}-${p.output}`));
+    expect(unique.size).toBeGreaterThan(1);
+  });
+});
+
+describe('calculateCost', () => {
+  it('calculates cost for Novita model', () => {
+    const cost = calculateCost('moonshotai/kimi-k2.5', 1_000_000, 1_000_000);
+    const pricing = MODEL_PRICING['moonshotai/kimi-k2.5'];
+    expect(cost).toBeCloseTo(pricing.input + pricing.output, 4);
+  });
+
+  it('falls back to default pricing for unknown model', () => {
+    const cost = calculateCost('unknown-model', 1_000_000, 1_000_000);
+    const pricing = MODEL_PRICING['default'];
+    expect(cost).toBeCloseTo(pricing.input + pricing.output, 4);
+  });
+});

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+    },
+  },
+});


### PR DESCRIPTION
## Summary

- Adds `'novita'` to the `LLMProvider` type union (`web/src/lib/llm/types.ts`)
- Registers Novita models in `MODEL_PRICING`: `moonshotai/kimi-k2.5` (default), `deepseek/deepseek-v3.2`, `zai-org/glm-5`
- Adds `novita` provider block to `docker/config/openclaw.json` with the OpenAI-compatible endpoint (`https://api.novita.ai/openai`), `NOVITA_API_KEY` env var, and all supported chat + embedding models (`qwen/qwen3-embedding-0.6b`)
- Documents `NOVITA_API_KEY` and usage instructions in `web/.env.docker.example`

## Provider details

| Field | Value |
|-------|-------|
| Endpoint | `https://api.novita.ai/openai` (OpenAI-compatible) |
| API key env | `NOVITA_API_KEY` |
| Default model | `moonshotai/kimi-k2.5` |
| Other chat models | `deepseek/deepseek-v3.2`, `zai-org/glm-5` |
| Embedding model | `qwen/qwen3-embedding-0.6b` |

## Test plan

- [ ] Set `NOVITA_API_KEY` and verify `novita` provider resolves in `ProviderConfig`
- [ ] Confirm `MODEL_PRICING` lookup works for all three Novita chat model IDs
- [ ] Start the Docker stack and verify the `novita` provider block loads cleanly in OpenClaw

🤖 Generated with [Claude Code](https://claude.com/claude-code)